### PR TITLE
Adding UTF8 Encoding to the Gemspec of documents to let it be served by Pow/Nack.

### DIFF
--- a/documents/social_stream-documents.gemspec
+++ b/documents/social_stream-documents.gemspec
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 Gem::Specification.new do |s|
   s.name = "social_stream-documents"
   s.version = "0.2.6"


### PR DESCRIPTION
Adding UTF-8 Encoding comment to handle non ASCII chars in the gemspec. This is required to make social stream work with Rails 3.1 and the pow web server which internally uses nack.
