### PR TITLE
Do not install ruby-debug on travis-ci.org, it only wastes time 

### DIFF
--- a/social_stream.gemspec
+++ b/social_stream.gemspec
@@ -29,8 +29,10 @@ Gem::Specification.new do |s|
     s.add_development_dependency('sqlite3')
   end
   # Debugging
-  if RUBY_VERSION < '1.9'
-    s.add_development_dependency('ruby-debug', '~> 0.10.3')
+  unless ENV["CI"]
+    if RUBY_VERSION < '1.9'
+      s.add_development_dependency('ruby-debug', '~> 0.10.3')
+    end
   end
   # Specs
   s.add_development_dependency('rspec-rails', '~> 2.5.0')


### PR DESCRIPTION
Please read [Exclude non-essential gems like ruby-debug](http://about.travis-ci.org/docs/user/languages/ruby/) section in the documentation to learn how wasteful ruby-debug installation is.
