### PR TITLE
Correct typo in actor.rb comment

### DIFF
--- a/base/app/models/actor.rb
+++ b/base/app/models/actor.rb
@@ -5,7 +5,7 @@
 # type of a {Tie} is a {Relation}. Each actor can define and customize their relations own
 # {Relation Relations}.
 #
-# Every {Actor} has an Avatar, a {Profile} with personal o group information, contact data, etc.
+# Every {Actor} has an Avatar, a {Profile} with personal or group information, contact data, etc.
 #
 # {Actor Actors} perform {ActivityAction actions} (like, suscribe, etc.) on
 # {ActivityObject activity objects} ({Post posts}, {Comment commments}, pictures, events..)


### PR DESCRIPTION
I think this is a correction of a typo in the documentation for `Actor`. I'm not sure if that what was meant, but it was how I read it.
