### PR TITLE
update devise and cancan gem depedencies

### DIFF
--- a/base/lib/generators/social_stream/base/install_generator.rb
+++ b/base/lib/generators/social_stream/base/install_generator.rb
@@ -13,7 +13,7 @@ class SocialStream::Base::InstallGenerator < Rails::Generators::Base #:nodoc:
                       \n  config.omniauth :facebook, \"129571360447856\",\"eef39dce5e20e76f77495c59623bdb38\"
                       \n  #config.omniauth :twitter, \"wgTxO0fTpjTeSnjKC9ZHA\",\"JepulVWwLcuAnGfWjwCu47yEP0TcJJfKtvISPBsilI\"
                       \n  config.token_authentication_key = :auth_token
-                      \n  config.stateless_token = true",
+                      \n  config.skip_session_storage = [:token_auth]",
                       :after => "  # config.omniauth :github, 'APP_ID', 'APP_SECRET', :scope => 'user,public_repo'"
   end
 

--- a/base/social_stream-base.gemspec
+++ b/base/social_stream-base.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   # SQL foreign keys
   s.add_runtime_dependency('foreigner', '~> 1.1.1')
   # Authentication
-  s.add_runtime_dependency('devise', '~> 1.5.3')
+  s.add_runtime_dependency('devise', '~> 2.1.2')
   # CRUD controllers
   s.add_runtime_dependency('inherited_resources', '~> 1.3.0')
   # Slug generation
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   # jQuery
   s.add_runtime_dependency('jquery-rails', '>= 1.0.9')
   # Authorization
-  s.add_runtime_dependency('cancan', '1.6.7')
+  s.add_runtime_dependency('cancan', '~> 1.6.7')
   # Pagination
   s.add_runtime_dependency('kaminari', '~> 0.13.0')
   # OAuth client

--- a/base/spec/dummy/config/initializers/devise.rb
+++ b/base/spec/dummy/config/initializers/devise.rb
@@ -93,10 +93,6 @@ Devise.setup do |config|
   # If true, extends the user's remember period when remembered via cookie.
   # config.extend_remember_period = false
 
-  # If true, uses the password salt as remember token. This should be turned
-  # to false if you are not using database authenticatable.
-  config.use_salt_as_remember_token = true
-
   # Options to be passed to the created cookie. For instance, you can set
   # :secure => true in order to force SSL only cookies.
   # config.cookie_options = {}
@@ -159,11 +155,7 @@ Devise.setup do |config|
   # ==> Configuration for :token_authenticatable
   # Defines name of the authentication token params key
   # config.token_authentication_key = :auth_token
-
-  # If true, authentication through token does not store user in session and needs
-  # to be supplied on each request. Useful if you are using the token as API token.
-  # config.stateless_token = false
-
+  
   # ==> Scopes configuration
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
@@ -205,9 +197,11 @@ Devise.setup do |config|
   #config.omniauth :twitter, "wgTxO0fTpjTeSnjKC9ZHA","JepulVWwLcuAnGfWjwCu47yEP0TcJJfKtvISPBsilI"
                       
   config.token_authentication_key = :auth_token
-                      
-  config.stateless_token = true
 
+  #re state_less token removal 
+  #https://github.com/plataformatec/devise/issues/1499
+  config.skip_session_storage = [:token_auth]
+                      
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or
   # change the failure app, you can configure them inside the config.warden block.

--- a/documents/spec/dummy/config/initializers/devise.rb
+++ b/documents/spec/dummy/config/initializers/devise.rb
@@ -72,10 +72,6 @@ Devise.setup do |config|
   # If true, extends the user's remember period when remembered via cookie.
   # config.extend_remember_period = false
 
-  # If true, uses the password salt as remember token. This should be turned
-  # to false if you are not using database authenticatable.
-  config.use_salt_as_remember_token = true
-
   # ==> Configuration for :validatable
   # Range for password length. Default is 6..20.
   # config.password_length = 6..20
@@ -163,6 +159,10 @@ Devise.setup do |config|
   config.omniauth :linkedin, "ekxfXU8nueVSMQ9fc5KJAryBkyztUlCBYMW3DoQPzbE79WhivvzhQloRNHCHgPeB", "WYiHFT-KKFgjd45W3-pEAficmXRHmN6_6DGwj1C_ZILJlSO1gBvv6VNYXU9tybGY"
                       
   config.omniauth :facebook, "129571360447856","eef39dce5e20e76f77495c59623bdb38"
+
+  #re state_less token removal 
+  #https://github.com/plataformatec/devise/issues/1499
+  config.skip_session_storage = [:token_auth]
  
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/linkser/spec/dummy/config/initializers/devise.rb
+++ b/linkser/spec/dummy/config/initializers/devise.rb
@@ -72,10 +72,6 @@ Devise.setup do |config|
   # If true, extends the user's remember period when remembered via cookie.
   # config.extend_remember_period = false
 
-  # If true, uses the password salt as remember token. This should be turned
-  # to false if you are not using database authenticatable.
-  config.use_salt_as_remember_token = true
-
   # ==> Configuration for :validatable
   # Range for password length. Default is 6..20.
   # config.password_length = 6..20
@@ -122,11 +118,7 @@ Devise.setup do |config|
   # ==> Configuration for :token_authenticatable
   # Defines name of the authentication token params key
   # config.token_authentication_key = :auth_token
-
-  # If true, authentication through token does not store user in session and needs
-  # to be supplied on each request. Useful if you are using the token as API token.
-  # config.stateless_token = false
-
+  
   # ==> Scopes configuration
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
@@ -163,6 +155,10 @@ Devise.setup do |config|
   config.omniauth :linkedin, "ekxfXU8nueVSMQ9fc5KJAryBkyztUlCBYMW3DoQPzbE79WhivvzhQloRNHCHgPeB", "WYiHFT-KKFgjd45W3-pEAficmXRHmN6_6DGwj1C_ZILJlSO1gBvv6VNYXU9tybGY"
                       
   config.omniauth :facebook, "129571360447856","eef39dce5e20e76f77495c59623bdb38"
+  
+  #re state_less token removal 
+  #https://github.com/plataformatec/devise/issues/1499
+  config.skip_session_storage = [:token_auth]
  
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/spec/dummy/config/initializers/devise.rb
+++ b/spec/dummy/config/initializers/devise.rb
@@ -72,10 +72,6 @@ Devise.setup do |config|
   # If true, extends the user's remember period when remembered via cookie.
   # config.extend_remember_period = false
 
-  # If true, uses the password salt as remember token. This should be turned
-  # to false if you are not using database authenticatable.
-  config.use_salt_as_remember_token = true
-
   # ==> Configuration for :validatable
   # Range for password length. Default is 6..20.
   # config.password_length = 6..20
@@ -123,10 +119,6 @@ Devise.setup do |config|
   # Defines name of the authentication token params key
   # config.token_authentication_key = :auth_token
 
-  # If true, authentication through token does not store user in session and needs
-  # to be supplied on each request. Useful if you are using the token as API token.
-  # config.stateless_token = false
-
   # ==> Scopes configuration
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
@@ -163,6 +155,10 @@ Devise.setup do |config|
   config.omniauth :linkedin, "ekxfXU8nueVSMQ9fc5KJAryBkyztUlCBYMW3DoQPzbE79WhivvzhQloRNHCHgPeB", "WYiHFT-KKFgjd45W3-pEAficmXRHmN6_6DGwj1C_ZILJlSO1gBvv6VNYXU9tybGY"
                       
   config.omniauth :facebook, "129571360447856","eef39dce5e20e76f77495c59623bdb38"
+
+  #re state_less token removal 
+  #https://github.com/plataformatec/devise/issues/1499
+  config.skip_session_storage = [:token_auth]
  
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or


### PR DESCRIPTION
- devise
  = removed deprecated and removed configuration options
  = updated stateless_token devise configuration option.
  because it was injected into the file users will have to update that theirselves
- cancan
