### PR TITLE
Change the default activity objects in the initializer

### DIFF
--- a/base/lib/generators/social_stream/base/templates/initializer.rb
+++ b/base/lib/generators/social_stream/base/templates/initializer.rb
@@ -10,13 +10,13 @@ SocialStream.setup do |config|
   # config.devise_modules = :database_authenticatable, :registerable,
   #                         :recoverable, :rememberable, :trackable,
   #                         :omniauthable, :token_authenticatable
-  
+
   # Type of activities managed by actors
   # Remember you must add an "activity_object_id" foreign key column to your migration!
   #
-  # config.objects = [ :post, :comment ]
-  
-  # Form for activity objects to be loaded 
+  # config.objects = [ :post, :comment, :document, :event, :link ]
+
+  # Form for activity objects to be loaded
   # You can write your own activity objects
   #
   # config.activity_forms = [ :post, :document, :foo, :bar ]
@@ -31,10 +31,10 @@ SocialStream.setup do |config|
   # Expose resque interface to manage background tasks at /resque
   #
   # config.resque_access = true
- 
+
   # Quick search (header) and Extended search models and its order. Remember to create
   # the indexes with thinking-sphinx if you are using customized models.
-  # 
+  #
   # config.quick_search_models = [:user, :group]
   # config.extended_search_models = [:user, :group]
 

--- a/base/lib/generators/social_stream/base/templates/initializer.rb
+++ b/base/lib/generators/social_stream/base/templates/initializer.rb
@@ -13,8 +13,9 @@ SocialStream.setup do |config|
 
   # Type of activities managed by actors
   # Remember you must add an "activity_object_id" foreign key column to your migration!
+  # Be sure to add the other modules of Social Stream you might be using (e.g. , :document, :event, :link ).
   #
-  # config.objects = [ :post, :comment, :document, :event, :link ]
+  # config.objects = [ :post, :comment ]
 
   # Form for activity objects to be loaded
   # You can write your own activity objects

--- a/base/lib/generators/social_stream/base/templates/initializer.rb
+++ b/base/lib/generators/social_stream/base/templates/initializer.rb
@@ -13,7 +13,7 @@ SocialStream.setup do |config|
 
   # Type of activities managed by actors
   # Remember you must add an "activity_object_id" foreign key column to your migration!
-  # Be sure to add the other modules of Social Stream you might be using (e.g. , :document, :event, :link ).
+  # Be sure to add the other modules of Social Stream you might be using (e.g. :document, :event, :link ).
   #
   # config.objects = [ :post, :comment ]
 


### PR DESCRIPTION
The instructions for adding new activity types says to add your new type to the
list of activity objects in the initializer. Once I uncommented what was there
I was unable to run my newly installed application since it didn't include the
additionally types that install along side social_stream.

I found my problem described in the Google Group https://groups.google.com/forum/?fromgroups=#!topic/social-stream/p5sYan7IH5c
but it could be easily averted by defaulting them to the list of the activity
objects commented out in the initializer. Maybe with an additional comment
about how you may need to adjust what is here to accommodate how you have
social_stream configured.
