### PR TITLE
Fixed jquery selector to match activity forms with underscored names

### DIFF
--- a/base/app/assets/javascripts/social_stream.wall.js.erb
+++ b/base/app/assets/javascripts/social_stream.wall.js.erb
@@ -34,7 +34,7 @@ SocialStream.Wall = (function(SS, $, undefined){
       $('.activity_form_selector').removeClass('selected');
       $(this).addClass('selected');
       $('#wrapper_activities_header form').hide();
-      $('#new_'+this.id.split("_")[1]).show();
+      $('#' + this.id.replace(/^select/, 'new')).show();
     });
   }
 


### PR DESCRIPTION
If an activity form name contains underscores, it's not shown when switching between forms on the wall. Rather than splitting the id, I suggest just replacing the prefix (since you assume the rest to be the same form name anyway) in the selector.
