### PR TITLE
Modularization of Ability

### DIFF
--- a/base/app/models/ability.rb
+++ b/base/app/models/ability.rb
@@ -1,2 +1,3 @@
-class Ability < SocialStream::Ability
+class Ability
+  include SocialStream::Ability
 end

--- a/base/lib/generators/social_stream/base/install_generator.rb
+++ b/base/lib/generators/social_stream/base/install_generator.rb
@@ -59,4 +59,40 @@ class SocialStream::Base::InstallGenerator < Rails::Generators::Base #:nodoc:
     Rake::Task['railties:install:migrations'].reenable
     Rake::Task['social_stream_base_engine:install:migrations'].invoke
   end
+
+  def create_ability_file
+    ability_code = [
+      "# Generator social_stream:install has modified this file. Please,",   #0
+      "# check everything is working ok, specially if the former `Ability`", #1
+      "# class inherited from another class or included another module",     #2
+      "class Ability",                                                       #3
+      "  include SocialStream::Ability",                                     #4
+      "",                                                                    #5
+      "  def initialize(subject)",                                           #6
+      "    super",                                                           #7
+      "",                                                                    #8
+      "    # Add your authorization rules here",                             #9
+      "    # For instance:",                                                 #10
+      "    #    can :create, Comment",                                       #11
+      "    #    can [:create, :destroy], Post do |p|",                       #12
+      "    #      p.actor_id == Actor.normalize_id(subject)",                #13
+      "    #    end",                                                        #14
+      "  end",                                                               #15
+      "end"]                                                                 #16
+    ability_file = 'app/models/ability.rb'
+
+    if FileTest.exists? ability_file
+      prepend_to_file ability_file, ability_code[0..2].join("\n")+"\n"
+      if not File.read(ability_file).include?("include SocialStream::Ability\n")
+        inject_into_file ability_file, ability_code[4..5].join("\n")+"\n", :after => /class Ability(.*)\n/
+      end
+      if File.read(ability_file).include?("def initialize\n")
+        inject_into_file ability_file, ability_code[7..14].join("\n")+"\n", :after => /def initialize(.*)\n/
+      else
+        inject_into_file ability_file, ability_code[5..15].join("\n")+"\n", :after => /include SocialStream::Ability\n/
+      end
+    else
+      create_file ability_file, ability_code[3..16].join("\n")
+    end
+  end
 end

--- a/base/lib/social_stream-base.rb
+++ b/base/lib/social_stream-base.rb
@@ -3,11 +3,14 @@ require 'social_stream/base/dependencies'
 
 # Provides your Rails application with social network and activity stream support
 module SocialStream
-  autoload :Ability,   'social_stream/ability'
+  autoload :Ability, 'social_stream/ability'
   autoload :ActivityStreams, 'social_stream/activity_streams'
   module ActivityStreams
     autoload :Supertype, 'social_stream/activity_streams/supertype'
     autoload :Subtype,   'social_stream/activity_streams/subtype'
+  end
+  module Base
+    autoload :Ability,   'social_stream/base/ability'
   end
   autoload :D3,        'social_stream/d3'
   autoload :Populate,  'social_stream/populate'

--- a/base/lib/social_stream/ability.rb
+++ b/base/lib/social_stream/ability.rb
@@ -1,7 +1,7 @@
-require 'social_stream/ability/base'
+require 'social_stream/base/ability'
 
 module SocialStream
-  class Ability
-    include SocialStream::Ability::Base
+  module Ability
+    include SocialStream::Base::Ability
   end
 end

--- a/base/lib/social_stream/base/ability.rb
+++ b/base/lib/social_stream/base/ability.rb
@@ -1,6 +1,6 @@
 module SocialStream
-  class Ability
-    module Base
+  module Base
+    module Ability
       include CanCan::Ability
 
       # Create a new ability for this user, who is currently representing subject

--- a/base/lib/social_stream/controllers/helpers.rb
+++ b/base/lib/social_stream/controllers/helpers.rb
@@ -90,7 +90,7 @@ module SocialStream
       # Override Cancan#current_ability method to use {#current_subject}
       def current_ability
         @current_ability ||=
-          Ability.new(current_subject)
+          ::Ability.new(current_subject)
       end
 
       private

--- a/events/lib/social_stream/events/engine.rb
+++ b/events/lib/social_stream/events/engine.rb
@@ -2,7 +2,7 @@ module SocialStream
   module Events
     class Engine < Rails::Engine
       initializer "social_stream-events.ability" do
-        SocialStream::Ability.class_eval do
+        SocialStream::Ability.module_eval do
           include SocialStream::Events::Ability
         end
       end


### PR DESCRIPTION
Before this patch, there were two 'Ability' classes: Ability and
SocialStream::Ability. Only 'SocialStream::Ability' was being used
for authorization by CanCan, though the one that was normally
superseded was 'Ability'.

After this patch, there is only one 'Ability' class, in app/models,
that includes the module SocialStream::Ability.

The events module has also been modified to overload
SocialStream::Ability with its rules.

Also, the generator social_stream:install has been
modified to create app/models/ability.rb
Thus, the user does not need to know that Ability should include
SocialStream::Ability and call the parent initializer when
overloading this class).
This generator detects if ability.rb exists and in this case
modifies it to include 'SocialStream::Ability'
