### PR TITLE
Fix #296 and remove a leftover undefined reference to edit_object_by?

### DIFF
--- a/documents/app/views/common_documents/_edit_form.html.erb
+++ b/documents/app/views/common_documents/_edit_form.html.erb
@@ -48,7 +48,7 @@
   <% end %>
 </div>
 
-<% if params[:editing].present? and params[:editing].eql?"true" and document.post_activity.edit_object_by?(current_subject) %>
+<% if params[:editing] && can?(:update, document) %>
   <%= javascript_tag do %>
     $(document).ready(function(){
       SocialStream.Repository.toggleDocumentMenu('edit');


### PR DESCRIPTION
A w/a to make resque workers properly start on Windows, also includes a fix for broken edit action from the tipsy menu in documents index
