### PR TITLE
Audio/video show partials use hardcoded swfPath

### DIFF
--- a/documents/app/views/audios/_audio_show.html.erb
+++ b/documents/app/views/audios/_audio_show.html.erb
@@ -8,8 +8,8 @@
     },
     supplied: "webma",
     preload: "none",
-  swfPath: "assets",
-  cssSelectorAncestor: "#jp_interface_<%=audio.id%>"
+    swfPath: "<%= asset_path("") %>",
+    cssSelectorAncestor: "#jp_interface_<%=audio.id%>"
   });
 
 <% end %>

--- a/documents/app/views/videos/_video_show.html.erb
+++ b/documents/app/views/videos/_video_show.html.erb
@@ -60,7 +60,7 @@
       solution:"flash, html",
       preload: "none",
       supplied: "webmv, flv, mp4",
-      swfPath: "assets",
+      swfPath: "<%= asset_path("") %>",
       cssSelectorAncestor: "#jp_interface_<%=video.id%>"
     });
   <% end %>


### PR DESCRIPTION
This makes swfPath relative to the current URL leading to weird 404 errors against jplayer.swf. Using asset_path instead of this works.
