### PR TITLE
Fixed issue with sidebar add button

### DIFF
--- a/base/app/assets/stylesheets/social_stream/base/mixins/_buttons.css.sass
+++ b/base/app/assets/stylesheets/social_stream/base/mixins/_buttons.css.sass
@@ -128,6 +128,8 @@
 @mixin btn-add
   font-size: 10px
   .btn-group
+    clear: left
+    margin-left: 55px
     button
       @include btn-primary
       &:hover

--- a/base/app/assets/stylesheets/social_stream/base/sidebar/_sidebar.css.sass
+++ b/base/app/assets/stylesheets/social_stream/base/sidebar/_sidebar.css.sass
@@ -24,6 +24,8 @@
 
       .add
         @include btn-add
+	clear: left
+	margin-left: 85px
          
 
     .see-more

--- a/base/app/assets/stylesheets/social_stream/base/sidebar/_sidebar.css.sass
+++ b/base/app/assets/stylesheets/social_stream/base/sidebar/_sidebar.css.sass
@@ -24,10 +24,6 @@
 
       .add
         @include btn-add
-	clear: left
-	margin-left: 85px
-         
-
     .see-more
       font-size: 12px
       line-height: 20px


### PR DESCRIPTION
When screen size is too wide, the Add button in the pendings/suggestions section covers the 'x' that dismisses the contact
