### PR TITLE
Removes the "change your avatar" heading that appears when viewing another user's or group's profile information

### DIFF
--- a/base/app/views/profiles/_avatar.html.erb
+++ b/base/app/views/profiles/_avatar.html.erb
@@ -1,11 +1,11 @@
 <section class="avatar">
-  <header>
-    <%= render partial: 'edit_icon' %>
-    <h4>
-      <%= t('avatar.profile_change') %>
-    </h4>
-  </header>
   <% if can? :update, @profile %>
+    <header>
+      <%= render partial: 'edit_icon' %>
+      <h4>
+        <%= t('avatar.profile_change') %>
+      </h4>
+    </header>
     <div class="update">
       <%= render partial: 'avatars/form',
                  object: @profile.actor,


### PR DESCRIPTION
Removed the "change your avatar" heading that appears when a user views another user's or group's profile information (as it does not make sense in the context). 

![ss](https://f.cloud.github.com/assets/3587125/564679/4ae9ea6a-c590-11e2-86c4-19a741d53a9a.png)
