### PR TITLE
Custom notification settings

### DIFF
--- a/base/app/controllers/settings_controller.rb
+++ b/base/app/controllers/settings_controller.rb
@@ -1,7 +1,7 @@
 class SettingsController < ApplicationController
-    
+
   before_filter :authenticate_user!
-  
+
   def index
   end
 
@@ -19,6 +19,16 @@ class SettingsController < ApplicationController
           notify_by_email = params[:notify_by_email].to_s
           current_subject.notify_by_email = false if notify_by_email.eql? "never"
           current_subject.notify_by_email = true if notify_by_email.eql? "always"
+        end
+
+        # Custom notification settings
+        if params[:notification_settings].present?
+          notification_settings = {}
+          params[:notification_settings].each_pair do |key, setting|
+            notification_settings[key.to_sym] = false if setting.eql? "never"
+            notification_settings[key.to_sym] = true if setting.eql? "always"
+          end
+          current_subject.update_attribute(:notification_settings, notification_settings)
         end
       end
 

--- a/base/app/models/actor.rb
+++ b/base/app/models/actor.rb
@@ -28,7 +28,13 @@ class Actor < ActiveRecord::Base
   acts_as_messageable
 
   acts_as_url :name, :url_attribute => :slug
-  
+
+  serialize :notification_settings
+  def notification_settings
+    self.update_attribute(:notification_settings, SocialStream.default_notification_settings) unless super
+    super
+  end
+
   has_one :profile,
           dependent: :destroy,
           inverse_of: :actor

--- a/base/app/views/settings/_notifications.html.erb
+++ b/base/app/views/settings/_notifications.html.erb
@@ -7,15 +7,23 @@
 
   <div class="content settings_content collapse" id="notifications_settings_content">
     <%= form_tag update_all_settings_path, :method => :put do %>
-    
+
     <%= t('settings.notifications.by_email.name')%>
 
-    <div class="options">          
+    <div class="options">
       <%= radio_button_tag :notify_by_email, 'always', current_subject.notify_by_email %> <%= t('settings.notifications.by_email.always') %>
       <%= radio_button_tag :notify_by_email, 'never', !current_subject.notify_by_email %> <%= t('settings.notifications.by_email.never') %>
     </div>
-  
-   
+
+    <% SocialStream.default_notification_settings.keys.each do |key| %>
+        <%= [t("settings.notification_settings.prefix"), t("settings.notification_settings.#{key}")].join " " %>
+
+        <div class="options">
+          <%= radio_button_tag "notification_settings[#{key}]", 'always', current_subject.notification_settings[key] %> <%= t('settings.notifications.by_email.always') %>
+          <%= radio_button_tag "notification_settings[#{key}]", 'never', !current_subject.notification_settings[key] %> <%= t('settings.notifications.by_email.never') %>
+        </div>
+    <% end %>
+
     <%= hidden_field_tag :settings_section, :notifications %>
     <%= submit_tag "Update Settings", :class => "btn" %>
     <% end %>

--- a/base/config/locales/en.yml
+++ b/base/config/locales/en.yml
@@ -578,6 +578,12 @@ en:
         name: "Send me an email when I receive a notification"
         always: "Always"
         never: "Never"
+    notification_settings:
+      prefix: "Send me an email"
+      someone_adds_me_as_a_contact: "when someone adds me as a contact"
+      someone_confirms_my_contact_request: "when someone confirms my contact request"
+      someone_likes_my_post: "when someone likes my post"
+      someone_comments_on_my_post: "when someone comments on my post"
     one: "Settings"
     password_change:
       briefing: "Change your password"

--- a/base/db/migrate/20120326083509_create_social_stream.rb
+++ b/base/db/migrate/20120326083509_create_social_stream.rb
@@ -81,6 +81,7 @@ class CreateSocialStream < ActiveRecord::Migration
       t.string   "slug"
       t.string   "subject_type"
       t.boolean  "notify_by_email",    :default => true
+      t.string   "notification_settings"
       t.datetime "created_at"
       t.datetime "updated_at"
       t.integer  "activity_object_id"

--- a/base/lib/generators/social_stream/base/templates/initializer.rb
+++ b/base/lib/generators/social_stream/base/templates/initializer.rb
@@ -49,6 +49,15 @@ SocialStream.setup do |config|
 
   # Cleditor controls. It is used in new message editor, for example
   # config.cleditor_controls = "bold italic underline strikethrough subscript superscript | size style | bullets | image link unlink"
+
+  # Default notification email settings for new users
+  # config.default_notification_settings = {
+  #   someone_adds_me_as_a_contact: true,
+  #   someone_confirms_my_contact_request: true,
+  #   someone_likes_my_post: true,
+  #   someone_comments_on_my_post: true
+  # }
+
 end
 
 # You can customize toolbar, sidebar and location bar from here

--- a/base/lib/social_stream/base.rb
+++ b/base/lib/social_stream/base.rb
@@ -45,7 +45,15 @@ module SocialStream
 
   mattr_accessor :cleditor_controls
   @@cleditor_controls = "bold italic underline strikethrough subscript superscript | size style | bullets | image link unlink"
- 
+
+  mattr_accessor :default_notification_settings
+  @@default_notification_settings = {
+      someone_adds_me_as_a_contact: true,
+      someone_confirms_my_contact_request: true,
+      someone_likes_my_post: true,
+      someone_comments_on_my_post: true
+  }
+
   class << self
     def setup
       yield self

--- a/base/social_stream-base.gemspec
+++ b/base/social_stream-base.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('omniauth-facebook','~> 1.4.1')
   s.add_runtime_dependency('omniauth-linkedin','~> 0.0.6')
   # Messages
-  s.add_runtime_dependency('mailboxer','~> 0.10.2')
+  s.add_runtime_dependency('mailboxer','~> 0.10.3')
   # Tagging
   s.add_runtime_dependency('acts-as-taggable-on','~> 2.2.2')
   # Background jobs


### PR DESCRIPTION
We had to implement some custom notification settings in our project. I'd just thought it would be useful in the base gem as well.
This way it is possible to disable email sending for some specific notification types (eg. when someone likes a post or comments on it)
